### PR TITLE
test diff_lower_and_upper_bound

### DIFF
--- a/tests.cpp
+++ b/tests.cpp
@@ -278,6 +278,27 @@ TEST(bimap, upper_bound) {
   EXPECT_EQ(b.upper_bound_left(400), b.end_left());
 }
 
+TEST(bimap, diff_lower_and_upper_bound)
+{
+  bimap<int, int> b;
+
+  std::vector<std::pair<int, int>> data = {
+      {1, 2}, {2, 3}, {3, 4}, {8, 16}, {32, 66}};
+
+  std::shuffle(data.begin(), data.end(), std::random_device{});
+  for (auto const& p : data) {
+    b.insert(p.first, p.second);
+  }
+
+  EXPECT_EQ(*b.lower_bound_left(5), *b.upper_bound_left(5));
+  EXPECT_NE(*b.lower_bound_left(8), *b.upper_bound_left(8));
+  EXPECT_EQ(*b.lower_bound_right(7), *b.upper_bound_right(7));
+  EXPECT_NE(*b.lower_bound_right(4), *b.upper_bound_right(4));
+
+  EXPECT_EQ(b.lower_bound_right(100), b.upper_bound_right(100));
+  EXPECT_EQ(b.lower_bound_left(100), b.upper_bound_left(100));
+}
+
 TEST(bimap, assigment) {
   bimap<int, int> a;
   a.insert(1, 4);

--- a/tests.cpp
+++ b/tests.cpp
@@ -278,8 +278,7 @@ TEST(bimap, upper_bound) {
   EXPECT_EQ(b.upper_bound_left(400), b.end_left());
 }
 
-TEST(bimap, diff_lower_and_upper_bound)
-{
+TEST(bimap, diff_lower_and_upper_bound) {
   bimap<int, int> b;
 
   std::vector<std::pair<int, int>> data = {


### PR DESCRIPTION
Добавил к исходным тестам проверку различия upper_bound и lower_bound. 

upper_bound -> _строго больше_           (Источник: https://en.cppreference.com/w/cpp/algorithm/upper_bound)
lower_bound ->  _больше или равно_    (Источник: https://en.cppreference.com/w/cpp/algorithm/lower_bound)


По хорошему, можно было бы просто добавить ешё несколько проверок в тест upper_bound, тк в нынешнем состоянии он не проверяет ситуацию на ключ который уже есть в bimap