### PR TITLE
Add end flip with state comparator test

### DIFF
--- a/test/correctness-test.cpp
+++ b/test/correctness-test.cpp
@@ -263,6 +263,19 @@ TEST(bimap, end_flip) {
   EXPECT_EQ(b.end_right().flip(), b.end_left());
 }
 
+TEST(bimap, end_flip_with_state_comparator) {
+  bimap<int, int, state_comparator, state_comparator> b;
+  EXPECT_EQ(b.end_left().flip(), b.end_right());
+  EXPECT_EQ(b.end_right().flip(), b.end_left());
+
+  b.insert(1, 2);
+  b.insert(-3, 5);
+  b.insert(1000, -100000);
+
+  EXPECT_EQ(b.end_left().flip(), b.end_right());
+  EXPECT_EQ(b.end_right().flip(), b.end_left());
+}
+
 TEST(bimap, total_flip) {
   bimap<int, int> b;
   b.insert(100, -100);


### PR DESCRIPTION
https://github.com/CPP-KT/bimap-NikitaMsln/pull/1/commits/5c30a7d2ccc81c1f7dc071197c48929768602cca

На этом коммите моя бимапа представляла собой 2 интрузив сета с разными конечными нодами, а ноды между ними были разделяемым.

Когда я делал флип, происходил статик каст из элемента сета одного тега в другой, что просто сдвигало указатель.

Когда происходил флип энда, если компаратор был разделяемым, то так как порядок наследования ноды от элементов сета совпадал с порядком хранения сетов, после флипа на энд указатель попадал в нужный энд другого сета, но если делать флип энд с хранимым компаратором, то такого трюка не выйдет.