### PR TITLE
Add instantiation test for non copy assignable type

### DIFF
--- a/test/correctness-test.cpp
+++ b/test/correctness-test.cpp
@@ -8,6 +8,9 @@
 template class bimap<int, non_default_constructible>;
 template class bimap<non_default_constructible, int>;
 
+template class bimap<int, non_copy_assignable>;
+template class bimap<non_copy_assignable, int>;
+
 TEST(bimap, simple) {
   bimap<int, int> b;
   b.insert(4, 4);

--- a/test/test-classes.h
+++ b/test/test-classes.h
@@ -87,6 +87,22 @@ private:
   int a;
 };
 
+class non_copy_assignable {
+public:
+  non_copy_assignable() = default;
+  non_copy_assignable(const non_copy_assignable&) = default;
+
+  non_copy_assignable& operator=(const non_copy_assignable&) = delete;
+
+  friend bool operator<(const non_copy_assignable&, const non_copy_assignable&) {
+    return false;
+  }
+
+  friend bool operator==(const non_copy_assignable&, const non_copy_assignable&) {
+    return true;
+  }
+};
+
 class address_checking_object {
 private:
   static std::unordered_set<const address_checking_object*> addresses;


### PR DESCRIPTION
Добавил проверку на то, что в bimap можно инстацировать типом, у которого нет оператора копирующего присваивания

Я использовал оператор присваивания в at_or_default: https://github.com/CPP-KT/bimap-bogdan-nikitin/pull/1#discussion_r1401103708