### PR TITLE
fixed prev update in Custom comparator test

### DIFF
--- a/test/correctness-test.cpp
+++ b/test/correctness-test.cpp
@@ -40,12 +40,12 @@ TEST_CASE("Custom comparator") {
   b.insert(10, -10);
 
   int prev = *b.begin_left();
-  for (auto it = ++b.begin_left(); it != b.end_left(); it++) {
+  for (auto it = std::next(b.begin_left()); it != b.end_left(); it++) {
     REQUIRE(prev > *it);
     prev = *it;
   }
   prev = *b.begin_right();
-  for (auto it = ++b.begin_right(); it != b.end_right(); it++) {
+  for (auto it = std::next(b.begin_right()); it != b.end_right(); it++) {
     REQUIRE(prev < *it);
     prev = *it;
   }

--- a/test/correctness-test.cpp
+++ b/test/correctness-test.cpp
@@ -42,10 +42,12 @@ TEST_CASE("Custom comparator") {
   int prev = *b.begin_left();
   for (auto it = ++b.begin_left(); it != b.end_left(); it++) {
     REQUIRE(prev > *it);
+    prev = *it;
   }
   prev = *b.begin_right();
   for (auto it = ++b.begin_right(); it != b.end_right(); it++) {
     REQUIRE(prev < *it);
+    prev = *it;
   }
 }
 


### PR DESCRIPTION
В тесте Custom comparator во время проверки инварианта итератора (элемент из предыдущего итератора меньше элемента текущего) не обновлялось значение элемента из предыдущего итератора